### PR TITLE
Add attributes to list alias on cakebuild.net

### DIFF
--- a/Cake.CoverageComparer/SimpleCoverageComparer.cs
+++ b/Cake.CoverageComparer/SimpleCoverageComparer.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 namespace Cake.CoverageComparer
 {
     [CakeNamespaceImport("Cake.CoverageComparer")]
+    [CakeAliasCategory("OpenCover")]
     public static class SimpleCoverageComparer
     {
         private static readonly CultureInfo _enUsCulture = CultureInfo.GetCultureInfo("en-US");
@@ -25,6 +26,7 @@ namespace Cake.CoverageComparer
         /// <param name="current">index.htm path from current branch</param>
         /// <returns>HTML table in markdown format</returns>
         [CakeMethodAlias]
+        [CakeAliasCategory("Compare")]
         public static async Task<string> CompareCoverage(this ICakeContext context, FilePath upstream, FilePath current)
         {
             var fromCurrentTable = await ExtractTableFromHtml(current.FullPath);


### PR DESCRIPTION
This will list the alias on the cakebuild.net website in the DSL reference at https://cakebuild.net/dsl/opencover/ and on the addin detail page at https://cakebuild.net/extensions/cake-coveragecomparer/.